### PR TITLE
make sure the key is always just the file nane without the path

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = function(fileName, opts) {
         firstFile;
     function transform(file, enc, callback) {
         var err;
-        var templateName = file.path.replace(file.cwd + '/', '');
+        var templateName = file.path.replace(file.cwd + '/', '').split('/').pop();
         pool[templateName] = file.contents.toString();
         if (!firstFile) firstFile = file;
         callback(err);


### PR DESCRIPTION
Having the key as `tpl/bar/baz.html` makes it difficult to move the templates folder as the key changes every time we pre-compile the templates. Having the key as just `baz.html` makes it simple IMHO.
